### PR TITLE
Download the RVM installation script and verify checksum before running.

### DIFF
--- a/1/debian9/1.13/Dockerfile
+++ b/1/debian9/1.13/Dockerfile
@@ -62,7 +62,10 @@ RUN found='' && \
 			&& found=yes && break; \
 	done; \
 	test -n "$found" \
-    && curl -sSL https://get.rvm.io | bash -s stable \
+    && curl -sSL -o get-rvm-io.sh https://get.rvm.io \
+    && (echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e get-rvm-io.sh" | sha256sum --check) \
+    && /bin/bash get-rvm-io.sh stable \
+    && rm -f get-rvm-io.sh \
     && /bin/bash -l -c "rvm install ${RUBY_VERSION}" \
     && /bin/bash -l -c "gem install --file Gemfile" \
     && ulimit -n 65536

--- a/1/debian9/1.2/Dockerfile
+++ b/1/debian9/1.2/Dockerfile
@@ -62,7 +62,10 @@ RUN found='' && \
 			&& found=yes && break; \
 	done; \
 	test -n "$found" \
-    && curl -sSL https://get.rvm.io | bash -s stable \
+    && curl -sSL -o get-rvm-io.sh https://get.rvm.io \
+    && (echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e get-rvm-io.sh" | sha256sum --check) \
+    && /bin/bash get-rvm-io.sh stable \
+    && rm -f get-rvm-io.sh \
     && /bin/bash -l -c "rvm install ${RUBY_VERSION}" \
     && /bin/bash -l -c "gem install --file Gemfile" \
     && ulimit -n 65536

--- a/templates/Dockerfile.template
+++ b/templates/Dockerfile.template
@@ -51,7 +51,10 @@ RUN cat "Gemfile.conf" | envsubst "\$FLUENTD_VERSION" > Gemfile \
     && rm -f Gemfile.conf
 
 RUN {{ `gpg --keyserver $server --recv-keys ${RUBY_GPG}` | KeyServersRetryLoop "\t" }} \
-    && curl -sSL https://get.rvm.io | bash -s stable \
+    && curl -sSL -o get-rvm-io.sh https://get.rvm.io \
+    && (echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e get-rvm-io.sh" | sha256sum --check) \
+    && /bin/bash get-rvm-io.sh stable \
+    && rm -f get-rvm-io.sh \
     && /bin/bash -l -c "rvm install ${RUBY_VERSION}" \
     && /bin/bash -l -c "gem install --file Gemfile" \
     && ulimit -n 65536

--- a/versions.yaml
+++ b/versions.yaml
@@ -26,10 +26,10 @@ versions:
       version: 2.6.5
   repo: fluentd1
   tags:
-  - 1.13.3-debian9
+  - 1.13.4-debian9
   - 1.13-debian9
   - 1-debian9
-  - 1.13.3
+  - 1.13.4
   - '1.13'
   - '1'
   - latest
@@ -43,8 +43,8 @@ versions:
       version: 2.5.7
   repo: fluentd1
   tags:
-  - 1.2.6-debian9
+  - 1.2.7-debian9
   - 1.2-debian9
-  - 1.2.6
+  - 1.2.7
   - '1.2'
 


### PR DESCRIPTION
This mitigates insecure behavior of piping a script from the internet
directly into a shell.